### PR TITLE
Fix being able to provide both 'file'/'embed' and 'files'/'embeds'

### DIFF
--- a/fluxer/http.py
+++ b/fluxer/http.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 from typing import Any
-from .models.embed import Embed
+import re
+import emoji as emoji_lib
+import urllib.parse
 
 import aiohttp
 import json as json_mod
 
 from .errors import http_exception_from_status
+
 
 log = logging.getLogger(__name__)
 
@@ -373,8 +377,7 @@ class HTTPClient:
         channel_id: int | str,
         *,
         content: str | None = None,
-        embed: Any | None = None,  # NEW (single embed support)
-        embeds: list[Any] | None = None,
+        embeds: list[dict[str, Any]] | None = None,
         files: list[Any] | None = None,
         message_reference: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -383,8 +386,7 @@ class HTTPClient:
         Args:
             channel_id: The channel to send the message to
             content: The message content
-            embed: Single embed object (optional)
-            embeds: List of embed objects (Embed or dict)
+            embeds: List of dict embed objects
             files: List of file objects to attach
             message_reference: Reference to another message for replies
                 Example: {"message_id": "123456789", "channel_id": "987654321"}
@@ -400,21 +402,8 @@ class HTTPClient:
         if content is not None:
             payload["content"] = content
 
-        # --- Normalize embed(s) ---
-
-        # Support single embed param
-        if embed is not None:
-            embeds = [embed]
-
-        # Normalize all embeds
         if embeds is not None:
-            normalized = []
-            for e in embeds:
-                if isinstance(e, Embed):
-                    normalized.append(e.to_dict())
-                else:
-                    normalized.append(e)
-            payload["embeds"] = normalized
+            payload["embeds"] = embeds
 
         if message_reference is not None:
             payload["message_reference"] = message_reference
@@ -627,7 +616,6 @@ class HTTPClient:
         Returns:
             Guild object
         """
-        import base64
 
         payload: dict[str, Any] = {"name": name}
 
@@ -663,7 +651,6 @@ class HTTPClient:
         **kwargs: Any,
     ) -> dict[str, Any]:
         """PATCH /guilds/{guild_id} — Modify guild settings."""
-        import base64
 
         payload: dict[str, Any] = {}
 
@@ -1179,7 +1166,6 @@ class HTTPClient:
         Returns:
             Updated user object
         """
-        import base64
 
         payload: dict[str, Any] = {}
 
@@ -1265,7 +1251,6 @@ class HTTPClient:
         Returns:
             Emoji object
         """
-        import base64
 
         # Convert bytes to base64 data URI
         image_data = base64.b64encode(image).decode("ascii")
@@ -1367,7 +1352,6 @@ class HTTPClient:
         Returns:
             Sticker object
         """
-        import base64
 
         # Convert bytes to base64 data URI
         image_data = base64.b64encode(image).decode("ascii")
@@ -1602,9 +1586,6 @@ class HTTPClient:
         Returns:
             URL-encoded emoji string or "name:id" for custom emojis
         """
-        import re
-        import emoji as emoji_lib
-        import urllib.parse
 
         # Handle PartialEmoji or Emoji objects
         if hasattr(emoji, "id") and emoji.id:

--- a/fluxer/models/channel.py
+++ b/fluxer/models/channel.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from fluxer.utils import process_embed_args
 
+from .message import Message
 from ..enums import ChannelType
 from ..utils import snowflake_to_datetime
 
@@ -15,7 +16,6 @@ if TYPE_CHECKING:
     from ..voice import VoiceClient
     from .embed import Embed
     from .guild import Guild
-    from .message import Message
 
 
 @dataclass(slots=True)
@@ -103,6 +103,9 @@ class Channel:
         Returns:
             The created Message object.
 
+        Raises:
+            TypeError: You specified both file, and files, or both embed, and embeds
+
         Examples:
             # Send a file from path
             from fluxer import File
@@ -115,15 +118,17 @@ class Channel:
             embed = Embed(title="Title")
             await channel.send(embed=embed, file=File("data.json"))
         """
-        # Import here to avoid circular imports
-        from .message import Message
-
         if self._http is None:
             raise RuntimeError("Channel is not bound to an HTTP client")
 
+        if embed is not None and embeds is not None:
+            raise TypeError("Cannot mix embed and embeds keyword arguments.")
+
+        if file is not None and files is not None:
+            raise TypeError("Cannot mix file and files keyword arguments.")
+
         # Auto-convert single embed to embeds list
-        combined_kwargs = {"embed": embed, "embeds": embeds}
-        combined_kwargs = process_embed_args(combined_kwargs)
+        embed_list = process_embed_args(embed, embeds)
 
         # Handle file/files parameter - convert File objects to dict format
         file_list: list[dict[str, Any]] | None = None
@@ -137,7 +142,7 @@ class Channel:
             content=content,
             files=file_list,
             message_reference=message_reference,
-            **combined_kwargs,
+            embeds=embed_list,
         )
         msg = Message.from_data(data, self._http)
         msg._channel = self
@@ -153,8 +158,6 @@ class Channel:
         Returns:
             The fetched Message object.
         """
-        from .message import Message
-
         if self._http is None:
             raise RuntimeError("Channel is not bound to an HTTP client")
 
@@ -173,8 +176,6 @@ class Channel:
         Returns:
             A list of Message objects.
         """
-        from .message import Message
-
         if self._http is None:
             raise RuntimeError("Channel is not bound to an HTTP client")
 
@@ -191,8 +192,6 @@ class Channel:
         Returns:
             A list of pinned Message objects.
         """
-        from .message import Message
-
         if self._http is None:
             raise RuntimeError("Channel is not bound to an HTTP client")
 

--- a/fluxer/models/message.py
+++ b/fluxer/models/message.py
@@ -118,13 +118,21 @@ class Message:
 
         Returns:
             The created Message object.
+
+        Raises:
+            TypeError: You specified both file, and files, or both embed, and embeds
         """
         if self._http is None:
             raise RuntimeError("Message is not bound to an HTTP client")
 
+        if embed is not None and embeds is not None:
+            raise TypeError("Cannot mix embed and embeds keyword arguments.")
+
+        if file is not None and files is not None:
+            raise TypeError("Cannot mix file and files keyword arguments.")
+
         # Auto-convert single embed to embeds list
-        combined_kwargs = {"embed": embed, "embeds": embeds, **kwargs}
-        combined_kwargs = process_embed_args(combined_kwargs)
+        embed_list = process_embed_args(embed, embeds)
 
         # Handle file/files parameter - convert File objects to dict format
         file_list: list[dict[str, Any]] | None = None
@@ -137,7 +145,8 @@ class Message:
             self.channel_id,
             content=content,
             files=file_list,
-            **combined_kwargs,
+            embeds=embed_list,
+            **kwargs,
         )
         msg = Message.from_data(data, self._http)
         msg._channel = self._channel
@@ -152,7 +161,6 @@ class Message:
         embeds: list[Any] | None = None,
         file: File | None = None,
         files: list[File] | None = None,
-        **kwargs: Any,
     ) -> Message:
         """Reply to this message with a message reference.
 
@@ -162,17 +170,24 @@ class Message:
             embeds: Multiple embeds to include.
             file: A single File object to attach.
             files: Multiple File objects to attach.
-            **kwargs: Additional arguments to pass to send_message
 
         Returns:
             The created Message object.
+
+        Raises:
+            TypeError: You specified both file, and files, or both embed, and embeds
         """
         if self._http is None:
             raise RuntimeError("Message is not bound to an HTTP client")
 
+        if embed is not None and embeds is not None:
+            raise TypeError("Cannot mix embed and embeds keyword arguments.")
+
+        if file is not None and files is not None:
+            raise TypeError("Cannot mix file and files keyword arguments.")
+
         # Auto-convert single embed to embeds list
-        combined_kwargs = {"embed": embed, "embeds": embeds, **kwargs}
-        combined_kwargs = process_embed_args(combined_kwargs)
+        embed_list = process_embed_args(embed, embeds)
 
         # Handle file/files parameter - convert File objects to dict format
         file_list: list[dict[str, Any]] | None = None
@@ -194,7 +209,7 @@ class Message:
             content=content,
             message_reference=message_reference,
             files=file_list,
-            **combined_kwargs,
+            embeds=embed_list,
         )
         msg = Message.from_data(data, self._http)
         msg._channel = self._channel
@@ -228,13 +243,21 @@ class Message:
 
         Returns:
             The created Message object.
+
+        Raises:
+            TypeError: You specified both file, and files, or both embed, and embeds
         """
         if self._http is None:
             raise RuntimeError("Message is not bound to an HTTP client")
 
+        if embed is not None and embeds is not None:
+            raise TypeError("Cannot mix embed and embeds keyword arguments.")
+
+        if file is not None and files is not None:
+            raise TypeError("Cannot mix file and files keyword arguments.")
+
         # Auto-convert single embed to embeds list
-        combined_kwargs = {"embed": embed, "embeds": embeds, **kwargs}
-        combined_kwargs = process_embed_args(combined_kwargs)
+        embed_list = process_embed_args(embed, embeds)
 
         # Handle file/files parameter - convert File objects to dict format
         file_list: list[dict[str, Any]] | None = None
@@ -244,7 +267,11 @@ class Message:
             file_list = [f.to_dict() for f in files]
 
         data = await self._http.send_message(
-            channel_id, content=content, files=file_list, **combined_kwargs
+            channel_id,
+            content=content,
+            files=file_list,
+            embeds=embed_list,
+            **kwargs,
         )
         msg = Message.from_data(data, self._http)
         msg._cache_guild(self._guild)

--- a/fluxer/utils.py
+++ b/fluxer/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import pkgutil
 import re
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from datetime import datetime, timezone
 from typing import Any, Literal
 
@@ -241,7 +241,10 @@ def search_directory(path: str) -> Iterator[str]:
             yield prefix + name
 
 
-def process_embed_args(kwargs: dict[str, Any]) -> dict[str, Any]:
+def process_embed_args(
+    embed: dict[str, Any] | Embed | None,
+    embeds: Sequence[dict[str, Any] | Embed] | None,
+) -> list[dict[str, Any]] | None:
     """Process embed/embeds arguments to ensure proper format.
 
     Converts:
@@ -249,25 +252,21 @@ def process_embed_args(kwargs: dict[str, Any]) -> dict[str, Any]:
     - embeds=[Embed(...)] -> embeds=[{...}]
     - embeds=[{...}] -> embeds=[{...}] (no change)
     """
+    embeds_normalized: list[dict[str, Any]]
+    if embeds:
+        embeds_normalized = [e.to_dict() if isinstance(e, Embed) else e for e in embeds]
+        return embeds_normalized
 
-    # Handle singular 'embed' parameter
-    if "embed" in kwargs:
-        embed = kwargs.pop("embed")
-        if embed is not None:
-            # Convert Embed object to dict
-            if isinstance(embed, Embed):
-                kwargs["embeds"] = [embed.to_dict()]
-            else:
-                # Assume it's already a dict
-                kwargs["embeds"] = [embed]
+    if not embed:
+        return None
 
-    # Handle plural 'embeds' parameter - convert any Embed objects to dicts
-    if "embeds" in kwargs and kwargs["embeds"] is not None:
-        kwargs["embeds"] = [
-            e.to_dict() if isinstance(e, Embed) else e for e in kwargs["embeds"]
-        ]
+    if isinstance(embed, Embed):
+        embeds_normalized = [embed.to_dict()]
+    else:
+        # Assume it's already a dict
+        embeds_normalized = [embed]
 
-    return kwargs
+    return embeds_normalized
 
 
 def escape_mentions(text: str) -> str:


### PR DESCRIPTION
## Summary

Raise a TypeError when attempting to send messages with both a 'file' and 'files', or both 'embed' and 'embeds' argument. This used to silently drop the 'embed' field, and/or the 'files' field.

## Checklist

- [x] I am following the [Contribution Guidelines](https://github.com/akarealemil/fluxer.py/blob/development/.github/CONTRIBUTING.md)

- [x] These changes modify code
  - [x] All code changes have been tested.
  - [x] This Pull Request contains breaking changes (such as removing/renaming methods or parameters)
  - [x] I ran a Ruff Formatting check
  - [x] I ran a Type Check
  - [x] My code is properly documented (comments and doc-strings)


- [ ] This Pull Request fixes an issue.
- [ ] This Pull Request adds one or more features.